### PR TITLE
refactor: 테스트 코드 구조 수정

### DIFF
--- a/src/backend/src/locale/locale.service.spec.ts
+++ b/src/backend/src/locale/locale.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { LocaleService } from './locale.service';
 import { LocaleRepository } from './locale.repository';
-import { DBService } from 'src/db/db.service';
+import { DB, DBService } from 'src/db/db.service';
 import * as fs from 'fs';
 import * as path from 'path';
 import { ConflictException } from '@nestjs/common';
@@ -10,6 +10,7 @@ import { convertUUID } from 'src/common/utils';
 describe('LocaleService Integration', () => {
   let service: LocaleService;
   let dbService: DBService;
+  let db: DB;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -19,7 +20,7 @@ describe('LocaleService Integration', () => {
     service = module.get<LocaleService>(LocaleService);
     dbService = module.get<DBService>(DBService);
 
-    const db = await dbService.get();
+    db = await dbService.get();
     const testData = JSON.parse(
       fs.readFileSync(
         path.resolve(__dirname, '../../test/test-db.json'),
@@ -38,7 +39,6 @@ describe('LocaleService Integration', () => {
   });
 
   it('순서가 바뀐 locales를 올바르게 정렬하여 반환', async () => {
-    const db = await dbService.get();
     const testData = JSON.parse(
       fs.readFileSync(
         path.resolve(__dirname, '../../test/test-db.json'),
@@ -76,7 +76,6 @@ describe('LocaleService Integration', () => {
 
     await service.add(newLocale);
 
-    const db = await dbService.get();
     const locales = db.get('locales').value();
 
     expect(locales).toContainEqual(expect.objectContaining(newLocale));
@@ -98,7 +97,6 @@ describe('LocaleService Integration', () => {
 
     await service.editLabel(updatedLocale);
 
-    const db = await dbService.get();
     const locales = db.get('locales').value();
 
     expect(locales).toContainEqual(
@@ -125,7 +123,6 @@ describe('LocaleService Integration', () => {
 
     await service.editPosition({ locales: updateLocales });
 
-    const db = await dbService.get();
     const locales = db.get('locales').sortBy('position').value();
 
     expect(locales).toEqual([
@@ -139,7 +136,6 @@ describe('LocaleService Integration', () => {
 
     await service.delete({ id: localeId });
 
-    const db = await dbService.get();
     const locales = db.get('locales').value();
 
     expect(locales).not.toContainEqual(

--- a/src/backend/src/locale/locale.service.spec.ts
+++ b/src/backend/src/locale/locale.service.spec.ts
@@ -1,18 +1,30 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { LocaleService } from './locale.service';
 import { LocaleRepository } from './locale.repository';
-import { DB, DBService } from 'src/db/db.service';
-import * as fs from 'fs';
-import * as path from 'path';
+import { DB, DBService, LocaleSchema } from 'src/db/db.service';
 import { ConflictException } from '@nestjs/common';
-import { convertUUID } from 'src/common/utils';
+import { generateUUID } from 'src/common/utils';
+import { LocaleFactory } from 'src/test/factories/locale.factory';
 
 describe('LocaleService Integration', () => {
   let service: LocaleService;
   let dbService: DBService;
   let db: DB;
+  let factory: LocaleFactory;
+  const initialLocales: LocaleSchema[] = [
+    {
+      id: generateUUID(),
+      label: 'en',
+      position: 0,
+    },
+    {
+      id: generateUUID(),
+      label: 'ko',
+      position: 1,
+    },
+  ];
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [LocaleService, LocaleRepository, DBService],
     }).compile();
@@ -21,68 +33,57 @@ describe('LocaleService Integration', () => {
     dbService = module.get<DBService>(DBService);
 
     db = await dbService.get();
-    const testData = JSON.parse(
-      fs.readFileSync(
-        path.resolve(__dirname, '../../test/test-db.json'),
-        'utf-8',
-      ),
-    );
-    db.setState(testData).write();
+    factory = new LocaleFactory(db);
+  });
+
+  beforeEach(async () => {
+    db.setState({
+      locales: [...initialLocales],
+      groups: [],
+      translations: [],
+    }).write();
   });
 
   it('모든 locales 반환 성공', async () => {
     const result = await service.getAll();
-    expect(result.locales).toEqual([
-      { id: '9094373b-d01c-4359-bf18-3cc66a04505b', label: 'en', position: 0 },
-      { id: 'c50010a4-7c43-432d-89d2-2cac5e44eee2', label: 'ko', position: 1 },
-    ]);
+
+    expect(result.locales).toEqual(initialLocales);
   });
 
   it('순서가 바뀐 locales를 올바르게 정렬하여 반환', async () => {
-    const testData = JSON.parse(
-      fs.readFileSync(
-        path.resolve(__dirname, '../../test/test-db.json'),
-        'utf-8',
-      ),
-    );
-
-    // 'ko'와 'en'의 순서를 바꿈
-    const modifiedTestData = {
-      ...testData,
-      locales: [
-        {
-          id: 'c50010a4-7c43-432d-89d2-2cac5e44eee2',
-          label: 'ko',
-          position: 1,
-        },
-        {
-          id: '9094373b-d01c-4359-bf18-3cc66a04505b',
-          label: 'en',
-          position: 0,
-        },
-      ],
-    };
-    db.setState(modifiedTestData).write();
+    const enLocale = factory.create({
+      label: initialLocales[0].label,
+      position: 1,
+    });
+    const koLocale = factory.create({
+      label: initialLocales[1].label,
+      position: 0,
+    });
+    db.setState({
+      locales: [enLocale, koLocale],
+      groups: [],
+      translations: [],
+    }).write();
 
     const result = await service.getAll();
-    expect(result.locales).toEqual([
-      { id: '9094373b-d01c-4359-bf18-3cc66a04505b', label: 'en', position: 0 },
-      { id: 'c50010a4-7c43-432d-89d2-2cac5e44eee2', label: 'ko', position: 1 },
-    ]);
+
+    const expectedLocales = [koLocale, enLocale];
+    expect(result.locales).toEqual(expectedLocales);
   });
 
   it('새로운 locale을 정상적으로 추가', async () => {
     const newLocale = { label: 'fr', position: 2 };
-
     await service.add(newLocale);
 
     const locales = db.get('locales').value();
-
     expect(locales).toContainEqual(expect.objectContaining(newLocale));
   });
 
   it('이미 존재하는 locale label 추가 시 ConflictException 발생', async () => {
-    const existingLocale = { label: 'en', position: 2 };
+    const existingLocale = factory.create({
+      label: initialLocales[0].label,
+      position: 2,
+    });
 
     await expect(service.add(existingLocale)).rejects.toThrow(
       ConflictException,
@@ -91,14 +92,12 @@ describe('LocaleService Integration', () => {
 
   it('locale의 label을 정상적으로 업데이트', async () => {
     const updatedLocale = {
-      id: convertUUID('9094373b-d01c-4359-bf18-3cc66a04505b'),
+      id: initialLocales[0].id,
       newLabel: 'fr',
     };
-
     await service.editLabel(updatedLocale);
 
     const locales = db.get('locales').value();
-
     expect(locales).toContainEqual(
       expect.objectContaining({ id: updatedLocale.id, label: 'fr' }),
     );
@@ -106,8 +105,8 @@ describe('LocaleService Integration', () => {
 
   it('이미 존재하는 locale label로 업데이트 시 ConflictException 발생', async () => {
     const updatedLocale = {
-      id: convertUUID('9094373b-d01c-4359-bf18-3cc66a04505b'),
-      newLabel: 'ko',
+      id: initialLocales[0].id,
+      newLabel: initialLocales[1].label,
     };
 
     await expect(service.editLabel(updatedLocale)).rejects.toThrow(
@@ -117,29 +116,24 @@ describe('LocaleService Integration', () => {
 
   it('여러 locales의 위치를 정상적으로 업데이트', async () => {
     const updateLocales = [
-      { id: convertUUID('9094373b-d01c-4359-bf18-3cc66a04505b'), position: 1 }, // 'en'을 1번 위치로
-      { id: convertUUID('c50010a4-7c43-432d-89d2-2cac5e44eee2'), position: 0 }, // 'ko'를 0번 위치로
+      { id: initialLocales[0].id, position: 1 },
+      { id: initialLocales[1].id, position: 0 },
     ];
-
     await service.editPosition({ locales: updateLocales });
 
     const locales = db.get('locales').sortBy('position').value();
-
     expect(locales).toEqual([
-      { id: 'c50010a4-7c43-432d-89d2-2cac5e44eee2', label: 'ko', position: 0 },
-      { id: '9094373b-d01c-4359-bf18-3cc66a04505b', label: 'en', position: 1 },
+      expect.objectContaining({ label: initialLocales[1].label, position: 0 }),
+      expect.objectContaining({ label: initialLocales[0].label, position: 1 }),
     ]);
   });
 
   it('존재하는 locale 삭제 성공', async () => {
-    const localeId = '9094373b-d01c-4359-bf18-3cc66a04505b';
-
-    await service.delete({ id: localeId });
+    await service.delete({ id: initialLocales[0].id });
 
     const locales = db.get('locales').value();
-
     expect(locales).not.toContainEqual(
-      expect.objectContaining({ id: localeId }),
+      expect.objectContaining({ id: initialLocales[0].id }),
     );
   });
 });

--- a/src/backend/src/locale/locale.service.spec.ts
+++ b/src/backend/src/locale/locale.service.spec.ts
@@ -7,6 +7,7 @@ import { generateUUID } from 'src/common/utils';
 import { LocaleFactory } from 'src/test/factories/locale.factory';
 
 describe('LocaleService Integration', () => {
+  let module: TestingModule;
   let service: LocaleService;
   let dbService: DBService;
   let db: DB;
@@ -25,7 +26,7 @@ describe('LocaleService Integration', () => {
   ];
 
   beforeAll(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    module = await Test.createTestingModule({
       providers: [LocaleService, LocaleRepository, DBService],
     }).compile();
 
@@ -42,6 +43,10 @@ describe('LocaleService Integration', () => {
       groups: [],
       translations: [],
     }).write();
+  });
+
+  afterAll(async () => {
+    await module.close();
   });
 
   it('모든 locales 반환 성공', async () => {

--- a/src/backend/src/test/factories/locale.factory.ts
+++ b/src/backend/src/test/factories/locale.factory.ts
@@ -1,0 +1,16 @@
+import { generateUUID } from 'src/common/utils';
+import { DB } from 'src/db/db.service';
+
+export class LocaleFactory {
+  constructor(private readonly db: DB) {}
+
+  create({ label, position }: { label: string; position: number }) {
+    const locale = {
+      id: generateUUID(),
+      label,
+      position,
+    };
+    this.db.get('locales').push(locale).write();
+    return locale;
+  }
+}


### PR DESCRIPTION
- 테스트 코드에서 매 번 test-db.json의 데이터에 의존하면 해당 파일 데이터 여부에 따라 테스트 코드가 꺠질 가능성이 높음
- 팩토리 함수를 통해 데이터를 생성하도록 하고, 해당 데이터를 기반으로 테스트 코드가 작동할 수 있도록 수정함